### PR TITLE
Link fixes to moved page of documentation

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -27,7 +27,7 @@ sections:
           With <a href="https://tardis-sn.github.io/tardis" target="_blank" rel="noopener nofollow">tardis</a> (our Monte Carlo radiative-transfer code), you can control simulation parameters and access physical properties of the model in an intuitive way.
         actions:
           - label: Learn More
-            url: https://tardis-sn.github.io/tardis/quickstart/quickstart.html
+            url: https://tardis-sn.github.io/tardis/quickstart.html
             style: secondary
             has_icon: true
             icon: arrow-right
@@ -89,7 +89,7 @@ sections:
     subtitle: Launch an interactive version of our quickstart Jupyter notebook
     actions:
       - label: Get Started
-        url: https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath=docs/quickstart/quickstart.ipynb
+        url: https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath=docs/quickstart.ipynb
         style: primary
   - section_id: twitter_widget
     type: twitter_widget

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -45,6 +45,6 @@ As members of the community,
 
 This code of conduct has been adapted from the _Astropy Code of Conduct_, which in turn uses parts of the _Python Software Foundation (PSF)_ code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](../team/community_roles.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](../team/community_roles.md); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](../team/community_roles) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](../team/community_roles); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
 This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -45,6 +45,6 @@ As members of the community,
 
 This code of conduct has been adapted from the _Astropy Code of Conduct_, which in turn uses parts of the _Python Software Foundation (PSF)_ code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](team/community_roles.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](team/community_roles.md); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](../team/community_roles.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](../team/community_roles.md); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
 This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -47,4 +47,4 @@ This code of conduct has been adapted from the _Astropy Code of Conduct_, which 
 
 **To report any violations of the code of conduct, please contact a member of the [TARDIS core team](team/community_roles.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](team/community_roles.md); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
-This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md). 
+This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -45,6 +45,6 @@ As members of the community,
 
 This code of conduct has been adapted from the _Astropy Code of Conduct_, which in turn uses parts of the _Python Software Foundation (PSF)_ code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](https://tardis-sn.github.io/tardis/team_and_governance/team.html) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](https://tardis-sn.github.io/tardis/team_and_governance/team.html); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](team/community_roles.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](team/community_roles.md); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
 This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -47,4 +47,4 @@ This code of conduct has been adapted from the _Astropy Code of Conduct_, which 
 
 **To report any violations of the code of conduct, please contact a member of the [TARDIS core team](team/community_roles.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](team/community_roles.md); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
-This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).
+This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md). 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
This fixes some links that no longer worked after the documentation restructure.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
https://smithis7.github.io/tardis-sn.github.io/branch/quickstart-link-fix/index.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
