### PR TITLE
Website doesn't build on fork

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 title: TARDIS
 baseURL: https://tardis-sn.github.io/
+canonifyurls: true
 params:
   base_font: nunito-sans
   palette: blue

--- a/layouts/_default/blog.html
+++ b/layouts/_default/blog.html
@@ -8,13 +8,13 @@
       <article class="cell post">
         <div class="card">
           {{ if $post.Params.thumb_image }}
-          <a class="post-thumbnail" href="{{ $post.URL }}">
+          <a class="post-thumbnail" href="{{ $post.RelPermalink }}">
             <img src="{{ $post.Params.thumb_image | relURL }}" alt="{{ $post.Params.thumb_image_alt }}" />
           </a>
           {{ end }}
           <div class="post-body">
             <header class="post-header">
-              <h2 class="post-title"><a href="{{ $post.URL }}">{{ $post.Params.title }}</a></h2>
+              <h2 class="post-title"><a href="{{ $post.RelPermalink }}">{{ $post.Params.title }}</a></h2>
             </header>
             <div class="post-excerpt">
               <p>{{ $post.Params.excerpt }}</p>

--- a/layouts/partials/action.html
+++ b/layouts/partials/action.html
@@ -2,7 +2,7 @@
 {{ $action_style := $action.style | default "link" }}
 {{ $action_icon := $action.icon | default "arrow-left" }}
 {{ $action_icon_pos := $action.icon_position | default "left" }}
-{{ $page_url := trim $.URL "/" }}
+{{ $page_url := trim $.RelPermalink "/" }}
 
 {{ if eq $action_style "dropdown"}}
     {{ if $action.has_icon }} 
@@ -13,7 +13,7 @@
     <div class="dropdown {{ if $action.has_icon }} has-icon{{ end }}">
     <!-- $action_item are all of the sub-items inside a dropdown item. -->
     {{ range $action_item := $action.sub_items }}
-        {{ $page_url := trim $.URL "/" }}
+        {{ $page_url := trim $.RelPermalink "/" }}
         {{ $action_url := trim $action_item.url "/" }}
         {{ $action_style := $action_item.style | default "link" }}
         {{ $include_dict := dict "action" $action_item }}

--- a/layouts/partials/dropdown_item.html
+++ b/layouts/partials/dropdown_item.html
@@ -2,7 +2,7 @@
 {{ $action_style := $action.style | default "link" }}
 {{ $action_icon := $action.icon | default "arrow-left" }}
 {{ $action_icon_pos := $action.icon_position | default "left" }}
-{{ $page_url := trim $.URL "/" }}
+{{ $page_url := trim $.RelPermalink "/" }}
 {{ $action_url := trim $action.url "/" }}
 <a href="{{ $action.url | relURL}}" class="{{ if eq $page_url $action_url }} current-menu-item{{ end }}dropdown-item">
     <span class="{{ if eq $action_icon_pos "right" }} order-first{{ end }} {{ if eq $action_url  $page_url }} current-menu-item{{ end }}"> {{ $action.label }} </span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
           <button id="menu-close" class="menu-toggle"><span class="screen-reader-text">Open Menu</span><span class="icon-close" aria-hidden="true"></span></button>
           <div class="menu menu-header">
             {{ range $action := $.Site.Params.header.nav_links }} 
-              {{ $page_url := trim $.URL "/" }}
+              {{ $page_url := trim $.RelPermalink "/" }}
               {{ $action_url := trim $action.url "/" }} 
               {{ $action_style := $action.style | default "link" }} 
               {{ if eq $action_style "dropdown" }}

--- a/layouts/partials/section_posts.html
+++ b/layouts/partials/section_posts.html
@@ -18,13 +18,13 @@
       <article class="cell post">
         <div class="card">
           {{ if $post.Params.thumb_image }}
-          <a class="post-thumbnail" href="{{ $post.URL }}">
+          <a class="post-thumbnail" href="{{ $post.RelPermalink }}">
             <img src="{{ $post.Params.thumb_image | relURL }}" alt="{{ $post.Params.thumb_image_alt }}" />
           </a>
           {{ end }}
           <div class="post-body">
             <header class="post-header">
-              <h3 class="post-title"><a href="{{ $post.URL }}">{{ $post.Params.title }}</a></h3>
+              <h3 class="post-title"><a href="{{ $post.RelPermalink }}">{{ $post.Params.title }}</a></h3>
             </header>
             <div class="post-excerpt">
               <p>{{ $post.Params.excerpt }}</p>


### PR DESCRIPTION
### :pencil: Description

<!--
**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 
-->


The website doesn't build since Hugo's version changed and `.URL` has been deprecated.
When building locally I got this error:

```
ERROR 2023/01/16 16:13:11 Page.URL is deprecated and will be removed in Hugo 0.93.0. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url
```

This PR addresses the above error.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
