### PR TITLE
Fix a typo on the intro page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -18,7 +18,7 @@ sections:
     background: white
     title: TARDIS at a Glance
     subtitle: >-
-      TARDIS packages provide several tools for physics calculation and visulaization to make your supernova research easier. 
+      TARDIS packages provide several tools for physics calculation and visualization to make your supernova research easier. 
     features:
       - title: Modeling supernovae made easy
         image: images/config_and_modeling.png


### PR DESCRIPTION
### :pencil: Description

Minor fix in a typo in the word 'visualization' on the intro page.


### :pushpin: Resources

[TARDIS](https://tardis-sn.github.io/)


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
@atharva-2001 