### PR TITLE
Update broken links in Code of Conduct

### DIFF
--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -45,6 +45,6 @@ As members of the community,
 
 This code of conduct has been adapted from the _Astropy Code of Conduct_, which in turn uses parts of the _Python Software Foundation (PSF)_ code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](./people/core) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](./people/core/#ombudsperson--anchor-offset); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](../people/core) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](../people/core#ombudsperson); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
 This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -45,6 +45,6 @@ As members of the community,
 
 This code of conduct has been adapted from the _Astropy Code of Conduct_, which in turn uses parts of the _Python Software Foundation (PSF)_ code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](./people/core.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](./people/core.md#ombudsperson--anchor-offset); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](./people/core) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](./people/core/#ombudsperson--anchor-offset); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
 This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -45,6 +45,6 @@ As members of the community,
 
 This code of conduct has been adapted from the _Astropy Code of Conduct_, which in turn uses parts of the _Python Software Foundation (PSF)_ code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](../team/community_roles) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](../team/community_roles); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](./people/core.md) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](./people/core.md#ombudsperson--anchor-offset); who is outside of the TARDIS collaboration and will treat reports confidentially).**
 
 This **_Code Of Conduct_** can be found [here](https://github.com/tardis-sn/tardis/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

There are two broken links at the bottom of the [Community Code of Conduct](https://tardis-sn.github.io/code_of_conduct/). I fixed them.

It is related to the report violations, and the broken links are related to the teams.

> To report any violations of the code of conduct, please contact a member of the [TARDIS core team](https://tardis-sn.github.io/team/community_roles) (the email [tardis.supernova.code@gmail.com](mailto:tardis.supernova.code@gmail.com) is monitored by the core team) or the Ombudsperson (see the [team page](https://tardis-sn.github.io/team/community_roles); who is outside of the TARDIS collaboration and will treat reports confidentially).

---

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 

I created a discussion https://github.com/tardis-sn/tardis-sn.github.io/discussions/79, but in this pull request I assumed the answers from TARDIS based on my logic and common sense.

This pull request `fix` the issue https://github.com/tardis-sn/tardis-sn.github.io/issues/81.


### :pushpin: Resources

Examples, notebooks, and links to useful references.

[https://tardis-sn.github.io/code_of_conduct/](https://tardis-sn.github.io/code_of_conduct/)


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
