### PR TITLE
fix connector 2025 link under events

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -152,7 +152,11 @@ params:
         style: redirect-link
         url: https://tardis-sn.github.io/tardis-con
       - label: TARDIS-connector
-        style: redirect-link
+        style: dropdown-link
+        sub_items:
+        - label: Connector 2025
+          style: redirect-link
+          url: https://tardis-sn.github.io/tardis-connector/2025
         url: https://tardis-sn.github.io/tardis-connector
       url: /events
     - label: News


### PR DESCRIPTION
Fixes #3337
On the TARDIS site under Events, the TARDIS Connector link now has a subtab for 2025 that points to the correct URL.
Changes:
Turned the Events → TARDIS-connector item from a single link into a dropdown.
Added a Connector 2025 subtab that links to
https://tardis-sn.github.io/tardis-connector/2025
instead of the old https://tardis-sn.github.io/connector25/.
File updated: config.yaml (nav under params.header.nav_links → Events).