### PR TITLE
Set empty string instead of null for GSoC Checklist dropdown url

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -173,7 +173,7 @@ params:
         - label: Accepted Checklist
           style: redirect-link
           url: /summer_of_code/accepted_checklist
-        url: null
+        url: ""
       - label: GSoC 2026 Ideas
         style: dropdown-link
         url: /summer_of_code/ideas


### PR DESCRIPTION
The GSoC Checklist nav item is a dropdown container with nested sub_items (Application Checklist, Accepted Checklist) and has no page of its own. Its url was null, which caused tardis-org-data's generator to crash when it did Path(item['url']).

### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
